### PR TITLE
Inject baseUrl to allow use of cdn-ed assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+
+## [0.4.1]
+### Added
+- support for assets deployed to cdn. If `fingerprint.prepend` is defined in the consuming project's `ember-cli-build.js` file, the specified path will be prepended to the AMD asset urls. If not present, the standard root-relative path of `/assets/SCRIPTNAME.js` is used.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ var dojoConfig = {
 }; 
 ```
 
+# Using a CDN for your application's assets
+When using `ember-cli-deploy` it is common to deploy the assets of an ember application to a different location (cdn) from the `index.html`. The [ember-cli-deploy](http://ember-cli.com/ember-cli-deploy/docs/v0.5.x/fingerprinting/) documentation discusess how to use fingerprinting to prepend fully-qualified urls to the asset locations. As of v0.4.1 of `ember-cli-amd` these same options are applied to the AMD related scripts that are injected into the page, thus allowing this to work smoothly with `ember-cli-deploy`.
+
 # Running
 
 * `ember server`

--- a/index.js
+++ b/index.js
@@ -172,7 +172,13 @@ module.exports = {
       fs.createReadStream(path.join(root, this.app.options.amd.configPath))
         .pipe(fs.createWriteStream(path.join(result.directory, 'assets/amd-config.js')));
     }
-    
+
+    var baseUrl = '';
+    if(this.app.options.fingerprint && this.app.options.fingerprint.prepend){
+      baseUrl = this.app.options.fingerprint.prepend;
+      console.info('ember-cli-amd: prepending  ' + baseUrl + ' for amd scripts.');
+    }
+
     // the amd builder is asynchronous. Ember-cli supports async addon functions. 
     return this.amdBuilder(result.directory).then(function () {
     
@@ -181,7 +187,8 @@ module.exports = {
         directory: result.directory,
         indexFile: this.app.options.outputPaths.app.html,
         sha: indexSha,
-        startSrc: 'assets/amd-start.js'
+        startSrc: 'assets/amd-start.js',
+        baseUrl: baseUrl
       }).then(function (result) {
         // Save the script list if we got one otherwise reuse the saved one
         if (result.scriptsAsString)
@@ -207,7 +214,8 @@ module.exports = {
         directory: result.directory,
         indexFile: 'tests/index.html',
         sha: testIndexSha,
-        startSrc: 'assets/amd-test-start.js'
+        startSrc: 'assets/amd-test-start.js',
+        baseUrl: baseUrl
       }).then(function (result) {
         // Save the script list if we got one otherwise reuse the saved one
         if (result.scriptsAsString)
@@ -267,13 +275,16 @@ module.exports = {
     
       // Add to the body the amd loading code
       var amdScripts = '';
-      if (this.app.options.amd.configPath)
-        amdScripts += '<script src="assets/amd-config.js">';
+      if (this.app.options.amd.configPath){
+        amdScripts += '<script src="' + config.baseUrl + 'assets/amd-config.js"></script>';
+      }
 
       var loaderSrc = this.app.options.amd.loader;
-      if (loaderSrc === 'requirejs' || loaderSrc === 'dojo')
-        loaderSrc = 'assets/built.js';
-      amdScripts += '</script><script src="' + loaderSrc + '"></script><script src="' + config.startSrc + '"></script>';
+      if (loaderSrc === 'requirejs' || loaderSrc === 'dojo'){
+        loaderSrc = config.baseUrl + 'assets/built.js';
+      }
+      amdScripts += '<script src="' + loaderSrc + '"></script>';
+      amdScripts += '<script src="' + config.baseUrl + config.startSrc + '"></script>';
       
       $('body').prepend(amdScripts);    
     

--- a/index.js
+++ b/index.js
@@ -176,7 +176,6 @@ module.exports = {
     var baseUrl = '';
     if(this.app.options.fingerprint && this.app.options.fingerprint.prepend){
       baseUrl = this.app.options.fingerprint.prepend;
-      console.info('ember-cli-amd: prepending  ' + baseUrl + ' for amd scripts.');
     }
 
     // the amd builder is asynchronous. Ember-cli supports async addon functions. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-amd",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Ember CLI Addon that can load AMD modules.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
Open Data uses ember-cli-deploy and sends all assets to a separate cdn location. When we upgraded to the 0.4.0 release, things broke because the paths to the amd assets were relative to index.html, and thus incorrect. 

This PR also adds a CHANGELOG.md file with a description of this change, as well as updates to the README.md with a descriion of how this works in conjunction with `ember-cli-deploy`