### PR TITLE
Inline amd config and start scripts inthe index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.4.1]
 ### Added
 - support for assets deployed to cdn. If `fingerprint.prepend` is defined in the consuming project's `ember-cli-build.js` file, the specified path will be prepended to the AMD asset urls. If not present, the standard root-relative path of `/assets/SCRIPTNAME.js` is used.
+
+## [0.4.4]
+### Added
+- support for inlining of scripts
+### Changed
+- if not inlined, the amd-start and amd-config scripts are fingerprinted to enable cache-busting
+- also ensured that other script tags in the body are not removed (i.e. google analytics)
+- removed debugging cruft from `start-templates.txt`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,4 +13,3 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - if not inlined, the amd-start and amd-config scripts are fingerprinted to enable cache-busting
 - also ensured that other script tags in the body are not removed (i.e. google analytics)
-- removed debugging cruft from `start-templates.txt`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var app = new EmberApp({
     configPath: 'config/dojo-config.js',
     // If using a local loader ('dojo' or 'rquirejs'), the path to the AMD library must be provided.
     libraryPath: 'bower_components/amdlibrary',
-    // When uing a local loader, we will build the AMD module using requirejs into a single file
+    // When using a local loader, we will build the AMD module using requirejs into a single file
     // The following properties allow to control the build
     // Optional: it defaults to vendor/build.js
     outputPath: 'vendor/build.js'
@@ -51,8 +51,12 @@ var app = new EmberApp({
     locale: 'en-us',
     // Optional: Will create a dependencies.txt that will list all the AMD dependencies in the application, default is false
     outputDependencyList: true,
+    // Optional, defaults to true. If `true` the amd-start and amd-config scripts will be inlined into index.html.
+    // This saves xhrs during application boot, so unless you are generating your index.html file on the fly (i.e. from node or rails)
+    // you should likely enable this.
+    inline: true,
     // RequireJS build configuration options
-    // Please refere to RequireJS docs for more information
+    // Please refer to RequireJS docs for more information
     // http://requirejs.org/docs/optimization.html
     buildConfig: {
       include: [
@@ -160,4 +164,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 A copy of the license is available in the repository's [LICENSE.md](LICENSE.md) file.
-

--- a/index.js
+++ b/index.js
@@ -29,31 +29,42 @@ var RSVP = require('rsvp');
 
 // The root of the project
 var root;
+// The finger printing base urls
+var fingerprintBaseUrl = '';
 // The set of AMD module names used in application. If this addon is used under
 // continuous build (ember build --watch or ember serve), we need to verify that
 // things have not changed in between two same function calls. We need variables
 // to capture the sate
 var modules = [];
 var modulesAsString = '';
-// The list of scripts from inside the index files
-var scriptsAsString;
-var testScriptsAsString;
-// The sha of the re-built index files
-var indexSha;
-var testIndexSha;
+// The original index files. We use this to rebuild the amd index files
+var indexHtml = {
+  app: {
+    original: '',
+    amd: '',
+    scriptsAsString: ''
+  },
+  test: {
+    original: '',
+    amd: '',
+    scriptsAsString: ''
+  }
+};
 // i18n locale
 var locale;
 // Template used to manufacture the start script
 var startTemplate = template(fs.readFileSync(path.join(__dirname, 'start-template.txt'), 'utf8'));
 
 var modulesToString = function modulesToString(modules) {
-  return modules.map(function (module) { return '"' + module + '"'; }).join(',');
+  return modules.map(function(module) {
+    return '"' + module + '"';
+  }).join(',');
 };
 var walk = function walk(dir) {
   // Recursively walk thru a directory and returns the collection of files
   var results = [];
   var list = fs.readdirSync(dir);
-  list.forEach(function (file) {
+  list.forEach(function(file) {
     file = path.join(dir, file);
     var stat = fs.statSync(file);
     if (stat && stat.isDirectory()) results = results.concat(walk(file));
@@ -63,23 +74,23 @@ var walk = function walk(dir) {
 };
 
 var getAMDModule = function getAMDModule(node, packages) {
-  
-  //We are only interested by the import declarations
+
+  // We are only interested by the import declarations
   if (node.type !== 'ImportDeclaration')
     return null;
 
   // Should not happen but we never know
   if (!node.source || !node.source.value)
-    return null; 
+    return null;
 
   // Should not happen but we never know
   var module = node.source.value;
   if (!module.length)
     return null;
-  
+
   // Test if the module name starts with one of the AMD package names.
   // If so then it's an AMD module we can return it otherwise return null.
-  var isAMD = packages.some(function (p) {
+  var isAMD = packages.some(function(p) {
     return module.indexOf(p + '/') === 0;
   });
 
@@ -90,11 +101,11 @@ module.exports = {
 
   name: 'ember-cli-amd',
 
-  included: function (app) {
+  included: function(app) {
     // Note: this functionis only called once even if using ember build --watch or ember serve
-    
+
     // This is the entry point for this addon. We will collect the amd definitions from the ember-cli-build.js and
-    // we will build the list off the amd modules usedby the application. 
+    // we will build the list off the amd modules usedby the application.
     root = app.project.root;
 
     // This addon relies on an 'amd' options in the ember-cli-build.js file
@@ -108,9 +119,10 @@ module.exports = {
       loader: 'requirejs',
       packages: [],
       outputDependencyList: false,
-      buildOuput: 'assets/built.js'
+      buildOuput: 'assets/built.js',
+      inline: true
     }, app.options.amd);
-        
+
     // Determine the type of loader. We only support requirejs, dojo, or the path to a cdn
     if (!app.options.amd.loader) {
       throw new Error('ember-cli-amd: You must specify a loader option the amd options in ember-cli-build.js.');
@@ -119,9 +131,14 @@ module.exports = {
     if ((app.options.amd.loader === 'requirejs' || app.options.amd.loader === 'dojo') && !app.options.amd.libraryPath) {
       throw new Error('ember-cli-amd: When using a local loader, you must specify its location with the amdBase property in the amd options in ember-cli-build.js.');
     }
+
+    // The finger printing base url
+    if (this.app.options.fingerprint && this.app.options.fingerprint.enabled && this.app.options.fingerprint.prepend) {
+      fingerprintBaseUrl = this.app.options.fingerprint.prepend;
+    }
   },
 
-  postprocessTree: function (type, tree) {
+  postprocessTree: function(type, tree) {
     if (!this.app.options.amd)
       return tree;
 
@@ -129,7 +146,7 @@ module.exports = {
       return tree;
 
     var outputPaths = this.app.options.outputPaths;
-    
+
     // Create the string replace patterns for the various application files
     // We will replace require and define function call by their pig-latin version
     var data = {
@@ -139,10 +156,13 @@ module.exports = {
         new RegExp(path.parse(outputPaths.tests.js).name + '(.*js)'),
         new RegExp(path.parse(outputPaths.testSupport.js.testSupport).name + '(.*js)')
       ],
-      patterns: [
-        { match: /(\W|^|["])define(\W|["]|$)/g, replacement: '$1efineday$2' },
-        { match: /(\W|^|["])require(\W|["]|$)/g, replacement: '$1equireray$2' }
-      ]
+      patterns: [{
+        match: /(\W|^|["])define(\W|["]|$)/g,
+        replacement: '$1efineday$2'
+      }, {
+        match: /(\W|^|["])require(\W|["]|$)/g,
+        replacement: '$1equireray$2'
+      }]
     };
     var dataTree = stringReplace(tree, data);
 
@@ -151,198 +171,219 @@ module.exports = {
       files: [
         new RegExp(path.parse(outputPaths.testSupport.js.testLoader).name + '(.*js)')
       ],
-      patterns: [
-        { match: /(\W|^|["])define(\W|["]|$)/g, replacement: '$1efineday$2' },
-        { match: /[^.]require([(])/g, replacement: 'equireray(' }
-      ]
+      patterns: [{
+        match: /(\W|^|["])define(\W|["]|$)/g,
+        replacement: '$1efineday$2'
+      }, {
+        match: /[^.]require([(])/g,
+        replacement: 'equireray('
+      }]
     };
 
     return stringReplace(dataTree, testLoader);
   },
 
-  postBuild: function (result) {
+  postBuild: function(result) {
+
     if (!this.app.options.amd)
-      return; 
-      
-    // When ember build --watch or ember serve are used, this function will be called over and over 
+      return;
+
+    // When ember build --watch or ember serve are used, this function will be called over and over
     // as a user updates code. We need to figure what we have to build or copy.
-  
-    // Copy the amd config file into the output.
-    if (this.app.options.amd.configPath) {
-      fs.createReadStream(path.join(root, this.app.options.amd.configPath))
-        .pipe(fs.createWriteStream(path.join(result.directory, 'assets/amd-config.js')));
-    }
 
-    var baseUrl = '';
-    if (this.app.options.fingerprint && this.app.options.fingerprint.enabled && this.app.options.fingerprint.prepend) {
-      baseUrl = this.app.options.fingerprint.prepend;
-    }
+    // the amd builder will build the amd into a single file using requirejs build if requested.
+    // If using a cdn for the amd library, this function is no-op. When the build is finished, we can update the
+    // index files.
+    return this.amdBuilder(result.directory).then(function() {
 
-    // the amd builder is asynchronous. Ember-cli supports async addon functions. 
-    return this.amdBuilder(result.directory).then(function () {
-    
-      // Rebuild the index files
-      var indexPromise = this.indexBuilder({
+      // There are two index files to deal with, the app index file and the test index file.
+      // We need to convert them from ember style to amd style.
+      // Amd style is made of 3 steps:
+      // - amd configuration (optional), controlled by the his.app.options.amd.configPath
+      // - loader: could be based on local build or from cdn
+      // - start of the app: load the amd modules used by the app and boorstrap the app
+
+      // Handle the amd config
+      var amdConfigScript;
+      if (this.app.options.amd.configPath) {
+
+        // Read the amd config
+        amdConfigScript = fs.readFileSync(path.join(root, this.app.options.amd.configPath), 'utf8');
+
+        // If the config has to be inlined in the index then we have nothing to do at this point.
+        // If the config doesn't have to be inlined then we need to copy the file and eventually fingerprint it.
+        // Note that when the config is not inlined the property amdConfig is the file name. If the config
+        // has to be inlined, the property amdConfig is the actual config to inline.
+        if (!this.app.options.amd.inline) {
+
+          // Only fingerprint if fingerprinting is enabled
+          var amdConfigFileName = 'assets/amd-config';
+          if (this.app.options.fingerprint && this.app.options.fingerprint.enabled) {
+            var amdConfigSha = sha(amdConfigScript);
+            amdConfigFileName += '-' + amdConfigSha;
+          }
+          amdConfigFileName += '.js';
+
+          // Copy the amd config into the output directory
+          fs.writeFileSync(path.join(result.directory, amdConfigFileName), amdConfigScript);
+
+          // The amdConfig will be the file path
+          amdConfigScript = amdConfigFileName;
+        }
+      }
+
+      // Rebuild the app index files
+      var indexBuildResult = this.indexBuilder({
         directory: result.directory,
         indexFile: this.app.options.outputPaths.app.html,
-        sha: indexSha,
-        startSrc: 'assets/amd-start.js',
-        baseUrl: baseUrl
-      }).then(function (result) {
-        // Save the script list if we got one otherwise reuse the saved one
-        if (result.scriptsAsString)
-          scriptsAsString = result.scriptsAsString;
-        else
-          result.scriptsAsString = scriptsAsString;
-        
-        // Save the new sha
-        indexSha = result.sha;
+        indexHtml: indexHtml.app,
+        amdConfigScript: amdConfigScript,
+        startSrc: 'amd-start',
+      });
 
-        // The list of scripts has changed or the list of amd modules has changed, either way rebuld the
-        // start script
-        this.startScriptBuilder(result);
+      // If requested, save the list of modules used
+      if (this.app.options.amd.outputDependencyList) {
+        fs.writeFileSync(path.join(result.directory, 'dependencies.txt'), indexBuildResult.namesAsString);
+      }
 
-        // If requested, save the list of modules used
-        if (!this.app.options.amd.outputDependencyList)
-          return;
-
-        fs.writeFileSync(path.join(result.directory, 'dependencies.txt'), result.namesAsString);
-      }.bind(this));
-
-      var testIndexPromise = this.indexBuilder({
+      // Rebuild the test index file
+      this.indexBuilder({
         directory: result.directory,
         indexFile: 'tests/index.html',
-        sha: testIndexSha,
-        startSrc: 'assets/amd-test-start.js',
-        baseUrl: baseUrl
-      }).then(function (result) {
-        // Save the script list if we got one otherwise reuse the saved one
-        if (result.scriptsAsString)
-          testScriptsAsString = result.scriptsAsString;
-        else
-          result.scriptsAsString = testScriptsAsString;
-
-        // Save the new sha
-        testIndexSha = result.sha;
-
-        // The list of scripts has changed or the list of amd modules has changed, either way rebuld the
-        // start script
-        this.startScriptBuilder(result);
-      }.bind(this)).catch(function () {
-        // If there is no tests/index.html, the function will reject
-        return;
+        indexHtml: indexHtml.test,
+        amdConfigScript: amdConfigScript,
+        startSrc: 'amd-test-start',
       });
-
-      return RSVP.all([indexPromise, testIndexPromise]);
     }.bind(this));
   },
 
-  indexBuilder: function (config) {
-    
-    // Load the index file    
-    var deferred = RSVP.defer();
+  indexBuilder: function(config) {
+    // If the current index html is not the same as teh one we built, it means
+    // that another extension must have forced to regenerate the index html or
+    // this is the first time this extension is running
     var indexPath = path.join(config.directory, config.indexFile);
-    fs.readFile(indexPath, 'utf8', function (err, indexHtml) {
-      if (err) {
-        deferred.reject(err);
-        return;
-      }
-      
-      // Sha the index file and check if we need to rebuild the index file
-      var newIndexSha = sha(indexHtml);
-      config.refreshed = config.sha !== newIndexSha;
-  
-      // If the indx file is still the same then we can leave  
-      if (!config.refreshed) {
-        deferred.resolve(config);
-        return;
-      }
-            
-      // Get the collection of scripts 
-      var $ = cheerio.load(indexHtml);
-      var scriptElements = $('body > script');
-      var scripts = [];
-      scriptElements.filter(function () {
-        return $(this).attr('src') !== undefined;
-      }).each(function () {
-        scripts.push("'" + $(this).attr('src') + "'");
-      });
-      config.scriptsAsString = scripts.join(',');
-    
-      // Remove the scripts tag
-      scriptElements.remove();
-    
-      // Add to the body the amd loading code
-      var amdScripts = '';
-      if (this.app.options.amd.configPath){
-        amdScripts += '<script src="' + config.baseUrl + 'assets/amd-config.js"></script>';
-      }
+    var currentIndexHtml = fs.readFileSync(indexPath, 'utf8');
+    if (currentIndexHtml !== config.indexHtml.amd) {
+      config.indexHtml.original = currentIndexHtml;
+    }
 
-      var loaderSrc = this.app.options.amd.loader;
-      if (loaderSrc === 'requirejs' || loaderSrc === 'dojo'){
-        loaderSrc = config.baseUrl + 'assets/built.js';
+    // Get the collection of scripts
+    var $ = cheerio.load(config.indexHtml.original);
+    var scriptElements = config.$('body > script');
+    var scripts = [];
+    scriptElements.filter(function() {
+      return $(this).attr('src') !== undefined;
+    }).each(function() {
+      scripts.push("'" + $(this).attr('src') + "'");
+    });
+    config.indexHtml.scriptsAsString = scripts.join(',');
+
+    // Remove the scripts tag
+    scriptElements.remove();
+
+    // Add the amd config
+    var amdScripts = '';
+    if (this.app.options.amd.configPath) {
+      if (this.app.options.amd.inline) {
+        amdScripts += '<script>' + config.amdConfigScript + '</script>';
+      } else {
+        amdScripts += '<script src="' + fingerprintBaseUrl + config.amdConfigScript + '"></script>';
       }
-      amdScripts += '<script src="' + loaderSrc + '"></script>';
-      amdScripts += '<script src="' + config.baseUrl + config.startSrc + '"></script>';
-      
-      $('body').prepend(amdScripts);    
-    
-      // Sha the new index
-      var html = beautify_html($.html(), { indent_size: 2 });
-      config.sha = sha(html);
-    
-      // Rewrite the index file
-      fs.writeFileSync(indexPath, html);
+    }
 
-      deferred.resolve(config);
-    }.bind(this));
+    // Add the loader
+    var loaderSrc = this.app.options.amd.loader;
+    if (loaderSrc === 'requirejs' || loaderSrc === 'dojo') {
+      loaderSrc = config.baseUrl + 'assets/built.js';
+    }
+    amdScripts += '<script src="' + loaderSrc + '"></script>';
 
-    return deferred.promise;
+    // Add the start scripts
+    var startScript = this.getStartScript(config);
+    if (this.app.options.amd.inline) {
+      // Inline the start script
+      amdScripts += '<script>' + startScript + '</script>';
+    } else {
+      // fingerprint the start script if necessary
+      var startFileName = 'assets/' + config.startSrc;
+      if (this.app.options.fingerprint && this.app.options.fingerprint.enabled) {
+        var startSha = sha(startScript);
+        startFileName += '-' + startSha;
+      }
+      startFileName += '.js';
+
+      // If we are not inlining, then we need to save the start script
+      fs.writeFileSync(path.join(config.directory, startFileName), beautify_js(startScript, {
+        indent_size: 2
+      }));
+
+      // Add the script tag
+      amdScripts += '<script src="' + fingerprintBaseUrl + startFileName + '"></script>';
+    }
+
+    // Add the scripts to the body
+    $('body').prepend(amdScripts);
+
+    // Beautify the index.html
+    var html = beautify_html($.html(), {
+      indent_size: 2
+    });
+
+    // Rewrite the index file
+    fs.writeFileSync(indexPath, html);
+
+    return config;
   },
 
-  startScriptBuilder: function (config) {
-    // Write the amd-start.js file    
+  getStartScript: function(config) {
+    // Write the amd-start.js file
     // Build different arrays representing the modules for the injection in the start script
-    var objs = modules.map(function (module, i) { return 'mod' + i; });
-    var names = modules.map(function (module) { return "'" + module + "'"; });
-    var adoptables = names.map(function (name, i) { return '{name:' + name + ',obj:' + objs[i] + '}'; });
+    var objs = modules.map(function(module, i) {
+      return 'mod' + i;
+    });
+    var names = modules.map(function(module) {
+      return "'" + module + "'";
+    });
+    var adoptables = names.map(function(name, i) {
+      return '{name:' + name + ',obj:' + objs[i] + '}';
+    });
 
     var namesAsString = names.join(',');
     var objsAsString = objs.join(',');
     var adoptablesAsString = adoptables.join(',');
-    
+
     // Set the namesAsString in the return object. It's needed later on.
     config.namesAsString = namesAsString;
-    
+
     // Create the object used by the template for the start script
-    var startScript = startTemplate({
+    config.startScript = startTemplate({
       names: namesAsString,
       objects: objsAsString,
       adoptables: adoptablesAsString,
-      scripts: config.scriptsAsString,
+      scripts: config.indexHtml.scriptsAsString,
       vendor: path.parse(this.app.options.outputPaths.vendor.js).name
     });
-
-    fs.writeFileSync(path.join(config.directory, config.startSrc), beautify_js(startScript, { indent_size: 2 }));
   },
 
-  findAMDModules: function () {
-    
+  findAMDModules: function() {
+
     // Get the list of javascript files fromt the application
-    var jsFiles = walk(path.join(root, 'app')).filter(function (file) {
+    var jsFiles = walk(path.join(root, 'app')).filter(function(file) {
       return file.indexOf('.js') > -1;
     });
-    
+
     // Collect the list of modules used from the amd packages
     var amdModules = [];
     var packages = this.app.options.amd.packages;
-    jsFiles.forEach(function (file) {
+    jsFiles.forEach(function(file) {
       // Use esprima to parse the javascript file and build the code tree
       var f = fs.readFileSync(file, 'utf8');
-      var ast = esprima.parse(f, { sourceType: 'module' });
-      
-      // Walk thru the esprima nodes and collect the amd modules from the import statements 
-      eswalk(ast, function (node) {
+      var ast = esprima.parse(f, {
+        sourceType: 'module'
+      });
+
+      // Walk thru the esprima nodes and collect the amd modules from the import statements
+      eswalk(ast, function(node) {
         var amdModule = getAMDModule(node, packages);
         if (!amdModule)
           return;
@@ -353,29 +394,29 @@ module.exports = {
     return _.uniq(amdModules).sort();
   },
 
-  amdBuilder: function (directory) {
-    
-    // Refresh the list of modules    
+  amdBuilder: function(directory) {
+
+    // Refresh the list of modules
     modules = this.findAMDModules();
     modulesAsString = modulesToString(modules);
-    
+
     // This is an asynchronous execution. We will use RSVP to be compliant with ember-cli
     var deferred = RSVP.defer();
-  
+
     // If we are using the cdn then we don't need to build
     if (this.app.options.amd.loader !== 'dojo' && this.app.options.amd.loader !== 'requirejs') {
       deferred.resolve();
       return deferred.promise;
     }
-    
-    // For dojo we need to add the dojo module in the list of modules for the build 
+
+    // For dojo we need to add the dojo module in the list of modules for the build
     if (this.app.options.amd.loader === 'dojo')
       modulesAsString = '"dojo/dojo",' + modulesAsString;
-  
+
     // Create the built loader file
     var boot = 'define([' + modulesAsString + '])';
     fs.writeFileSync(path.join(this.app.options.amd.libraryPath, 'main.js'), boot);
-    
+
     // Define the build config
     var buildConfig = {
       baseUrl: this.app.options.amd.libraryPath,
@@ -386,15 +427,15 @@ module.exports = {
       inlineText: false,
       include: []
     };
-  
+
     // For require js, we need to include the require module in the build via include
     if (this.app.options.amd.loader === 'requirejs')
       buildConfig.include = ['../requirejs/require'];
-  
+
     // Merge the user build config and the default build config and build
-    requirejs.optimize(merge(this.app.options.amd.buildConfig, buildConfig), function () {
+    requirejs.optimize(merge(this.app.options.amd.buildConfig, buildConfig), function() {
       deferred.resolve();
-    }, function (err) {
+    }, function(err) {
       deferred.reject(err);
     });
 

--- a/index.js
+++ b/index.js
@@ -269,7 +269,7 @@ module.exports = {
 
     // Get the collection of scripts
     var $ = cheerio.load(config.indexHtml.original);
-    var scriptElements = config.$('body > script');
+    var scriptElements = $('body > script');
     var scripts = [];
     scriptElements.filter(function() {
       return $(this).attr('src') !== undefined;

--- a/index.js
+++ b/index.js
@@ -269,7 +269,15 @@ module.exports = {
     // that another extension must have forced to regenerate the index html or
     // this is the first time this extension is running
     var indexPath = path.join(config.directory, config.indexFile);
-    var currentIndexHtml = fs.readFileSync(indexPath, 'utf8');
+
+    var currentIndexHtml;
+    try {
+      currentIndexHtml = fs.readFileSync(indexPath, 'utf8');
+    } catch (e) {
+      // no index file, we are done.
+      return;
+    }
+
     if (!config.indexHtml.original) {
       config.indexHtml.original = currentIndexHtml;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-amd",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "Ember CLI Addon that can load AMD modules.",
   "directories": {
     "doc": "doc",

--- a/start-template.txt
+++ b/start-template.txt
@@ -2,19 +2,19 @@ require([
   <%= names %>
 ], function (<%= objects %>) {
   var adoptables = [<%= adoptables %>];
-  
-  var re = new RegExp('<%= vendor %>(.*js)');
-  function recursiveRequire(i, a){
-    if (i >= a.length) return;
-    require([a[i]], function() {
-      if (re.test(a[i])){
+  var isVendor = new RegExp('<%= vendor %>(.*js)');
+  function recursiveRequire(i, scripts){
+    if (i >= scripts.length) {
+      return;
+    }
+    require([scripts[i]], function() {
+      if (isVendor.test(scripts[i])) {
         adoptables.forEach(function(adoptable){
           efineday(adoptable.name, [], function(){return adoptable.obj;});
         });
       }
-      recursiveRequire(++i, a);
+      recursiveRequire(++i, scripts);
     });
   }
-  
   recursiveRequire(0, [<%= scripts %>]);
 });


### PR DESCRIPTION
This implementation should support two scenarios via the ember-cli-build property amd.inline:
- inline = true (default): the amd config and the amd start scripts will be inlined in the index.html. This is to avoid xhr round trip for bootstrapping the application
- inline = false: the amd config and amd start scripts will be saved in the assets directory and loaded by the index file. 
If the config and start scripts are not inlined then then will be fingerprinted if requested.
