### PR TITLE
Only removes scripts with src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
-## [0.4.1]
-### Added
-- support for assets deployed to cdn. If `fingerprint.prepend` is defined in the consuming project's `ember-cli-build.js` file, the specified path will be prepended to the AMD asset urls. If not present, the standard root-relative path of `/assets/SCRIPTNAME.js` is used.
+## [0.4.5]
+### Changed
+- Only scripts with src !== undefined are removed from the body. This allows us to put Google Analytics in the page or other json payloads
 
 ## [0.4.4]
 ### Added
@@ -13,3 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - if not inlined, the amd-start and amd-config scripts are fingerprinted to enable cache-busting
 - also ensured that other script tags in the body are not removed (i.e. google analytics)
+
+## [0.4.1]
+### Added
+- support for assets deployed to cdn. If `fingerprint.prepend` is defined in the consuming project's `ember-cli-build.js` file, the specified path will be prepended to the AMD asset urls. If not present, the standard root-relative path of `/assets/SCRIPTNAME.js` is used.

--- a/index.js
+++ b/index.js
@@ -317,9 +317,10 @@ module.exports = {
     var $ = cheerio.load(config.indexHtml.original);
     var scriptElements = $('body > script');
     var scripts = [];
-    scriptElements.filter(function () {
+    var scriptsWithSrc = scriptElements.filter(function () {
       return $(this).attr('src') !== undefined;
-    }).each(function () {
+    });
+    scriptsWithSrc.each(function () {
       scripts.push("'" + $(this).attr('src') + "'");
     });
 
@@ -327,8 +328,8 @@ module.exports = {
     config.indexHtml.scriptsAsString = scripts.join(',');
     config.indexHtml.modulesAsString = config.modules.names;
 
-    // Remove the scripts tag
-    scriptElements.remove();
+    // Remove the scripts tagcd
+    scriptsWithSrc.remove();
 
     // Add the amd config
     var amdScripts = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-amd",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Ember CLI Addon that can load AMD modules.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
This postBuild step was removing all script tags in the body, which we noticed because it was stripping out our google analytics.

This minor change ensures that we only remove the script tags where src !== undefined

