### PR TITLE
Fix build crash related to ES6 functions with parameters with default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [0.4.6]
+### Fix
+- Fix esprima parsing issue for functions with parameters with a default value
+
 ## [0.4.5]
 ### Changed
 - Only scripts with src !== undefined are removed from the body. This allows us to put Google Analytics in the page or other json payloads

--- a/index.js
+++ b/index.js
@@ -81,6 +81,10 @@ var walk = function walk(dir) {
 
 var getAMDModule = function getAMDModule(node, packages) {
 
+  // It's possible that esprima parsed some nodes as undefined
+  if (!node)
+    return null;
+
   // We are only interested by the import declarations
   if (node.type !== 'ImportDeclaration')
     return null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-amd",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Ember CLI Addon that can load AMD modules.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
I was defining ES6 functions with parameters with a default value.
Esprima is getting a bit lost with such functions and is passing undefined nodes in the walker.
This is a fix that skips undefined nodes in the walker.