### PR TITLE
Convert all the require reference in test-loader to equireray

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ module.exports = {
     var dataTree = stringReplace(tree, data);
 
     // Special case for the test loader that is doing some funky stuff with require
+    // We basically decided to pig latin all require cases.
     var testLoader = {
       files: [
         new RegExp(path.parse(outputPaths.testSupport.js.testLoader).name + '(.*js)')
@@ -185,8 +186,17 @@ module.exports = {
         match: /(\W|^|["])define(\W|["]|$)/g,
         replacement: '$1efineday$2'
       }, {
-        match: /[^.]require([(])/g,
+        match: /require([.])/g,
+        replacement: 'equireray.'
+      }, {
+        match: /require([(])/g,
         replacement: 'equireray('
+      }, {
+        match: /require([ ])/g,
+        replacement: 'equireray '
+      }, {
+        match: /requirejs([.])/g,
+        replacement: 'equireray.'
       }]
     };
 


### PR DESCRIPTION
@odoe As we were using ember test --serve in our project we noticed that the test-loader was complaining.
After review, we found that some require reference should have been pig-latined as everything else in the ember stack.
I'm proposing to pig-latin any require reference. This is fixing our issues for now. I'm not 100% sure that other issues may not surface later on.

@jrowlingson 