### PR TITLE
Add support for package main shorthand in module names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Add support for package main shorthand in module names
+
 ## [0.4.7]
 ### Fix
 - Fix regular expression check for "require" in test loader

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ var getAMDModule = function getAMDModule(node, packages) {
   // Test if the module name starts with one of the AMD package names.
   // If so then it's an AMD module we can return it otherwise return null.
   var isAMD = packages.some(function (p) {
-    return module.indexOf(p + '/') === 0;
+    return module.indexOf(p + '/') === 0 || module === p;
   });
 
   return isAMD ? module : null;


### PR DESCRIPTION
FWIW - this works in my project, and doesn't seem to break any of the other package deps (just `esri`).

dojo config:
```
var dojoConfig = {
  async: true,
  packages: [
    {
      name: 'Mapillary',
      location: '//npmcdn.com/mapillary-js@1.4.2/dist',
      main: 'mapillary-js.min'
    }
  ]
};
```

ember-cli-amd config:
```
  amd: {
      loader: 'http://js.arcgis.com/3.15/init.js',
      packages: [
        'esri', 'Mapillary'
      ],
      inline: true,
      configPath: 'config/dojo-config.js',
    },
```

import:
```
import Mapillary from 'Mapillary';
import arcgisUtils from 'esri/arcgis/utils';
import esriBasemaps from 'esri/basemaps';
```

resolves #30 

