### PR TITLE
Don't replace #define with #efineday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Don't replace #define with #efineday
+
 ## [0.4.7]
 ### Fix
 - Fix regular expression check for "require" in test loader

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ module.exports = {
         new RegExp(path.parse(outputPaths.testSupport.js.testSupport).name + '(.*js)')
       ],
       patterns: [{
-        match: /(\W|^|["])define(\W|["]|$)/g,
+        match: /([^A-Za-z0-9_#]|^|["])define(\W|["]|$)/g,
         replacement: '$1efineday$2'
       }, {
         match: /(\W|^|["])require(\W|["]|$)/g,


### PR DESCRIPTION
Fixes an error I see when using this w/ ember-cli-mapillary, which is that the `{{mapillary-viewer}}` component is broken and you see several `three.min.js:711 THREE.WebGLShader: Shader couldn't compile.` errors, each followed by a warning like this:
```
THREE.WebGLShader: gl.getShaderInfoLog() vertex ERROR: 0:3: 'efineday' : invalid directive name 
ERROR: 0:4: 'efineday' : invalid directive name 
ERROR: 0:5: 'efineday' : invalid directive name 
ERROR: 0:6: 'efineday' : invalid directive name 
ERROR: 0:7: 'efineday' : invalid directive name 
ERROR: 0:8: 'efineday' : invalid directive name 
 1: precision highp float;
2: precision highp int;
3: #efineday SHADER_NAME ShaderMaterial
4: #efineday VERTEX_TEXTURES
5: #efineday GAMMA_FACTOR 2
6: #efineday MAX_BONES 251
7: #efineday DOUBLE_SIDED
8: #efineday NUM_CLIPPING_PLANES 0
9: uniform mat4 modelMatrix;
10: uniform mat4 modelViewMatrix;
11: uniform mat4 projectionMatrix;
12: uniform mat4 viewMatrix;
13: uniform mat3 normalMatrix;
14: uniform vec3 cameraPosition;
15: attribute vec3 position;
16: attribute vec3 normal;
17: attribute vec2 uv;
18: #ifdef USE_COLOR
19: 	attribute vec3 color;
20: #endif
21: #ifdef USE_MORPHTARGETS
22: 	attribute vec3 morphTarget0;
23: 	attribute vec3 morphTarget1;
24: 	attribute vec3 morphTarget2;
25: 	attribute vec3 morphTarget3;
26: 	#ifdef USE_MORPHNORMALS
27: 		attribute vec3 morphNormal0;
28: 		attribute vec3 morphNormal1;
29: 		attribute vec3 morphNormal2;
30: 		attribute vec3 morphNormal3;
31: 	#else
32: 		attribute vec3 morphTarget4;
33: 		attribute vec3 morphTarget5;
34: 		attribute vec3 morphTarget6;
35: 		attribute vec3 morphTarget7;
36: 	#endif
37: #endif
38: #ifdef USE_SKINNING
39: 	attribute vec4 skinIndex;
40: 	attribute vec4 skinWeight;
41: #endif
42: 
43: #ifdef GL_ES
44: precision highp float;
45: #endif
46: 
47: uniform mat4 projectorMat;
48: 
49: varying vec4 vRstq;
50: 
51: void main()
52: {
53:     vRstq = projectorMat * vec4(position, 1.0);
54:     gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
55: }
three.min.js:711 THREE.WebGLShader: Shader couldn't compile.(anonymous function) @ three.min.js:711(anonymous function) @ three.min.js:698acquireProgram @ three.min.js:709s @ three.min.js:605renderBufferDirect @ three.min.js:636q @ three.min.js:602render @ three.min.js:651ImagePlaneGLRenderer.render @ ImagePlaneGLRenderer.ts:90(anonymous function) @ GLRenderer.ts:192SafeSubscriber.__tryOrUnsub @ Subscriber.js:223SafeSubscriber.next @ Subscriber.js:172Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89DistinctUntilChangedSubscriber._next @ distinctUntilChanged.js:72Subscriber.next @ Subscriber.js:89FilterSubscriber._next @ filter.js:88Subscriber.next @ Subscriber.js:89CombineLatestSubscriber._tryProject @ combineLatest.js:142CombineLatestSubscriber.notifyNext @ combineLatest.js:126InnerSubscriber._next @ InnerSubscriber.js:23Subscriber.next @ Subscriber.js:89Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89ScanSubscriber._tryNext @ scan.js:104ScanSubscriber._next @ scan.js:91Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89OuterSubscriber.notifyNext @ OuterSubscriber.js:19InnerSubscriber._next @ InnerSubscriber.js:23Subscriber.next @ Subscriber.js:89MapSubscriber._next @ map.js:82Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89MapSubscriber._next @ map.js:82Subscriber.next @ Subscriber.js:89DistinctUntilChangedSubscriber._next @ distinctUntilChanged.js:72Subscriber.next @ Subscriber.js:89FilterSubscriber._next @ filter.js:88Subscriber.next @ Subscriber.js:89ScanSubscriber._tryNext @ scan.js:104ScanSubscriber._next @ scan.js:91Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89MapSubscriber._next @ map.js:82Subscriber.next @ Subscriber.js:89Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89MapSubscriber._next @ map.js:82Subscriber.next @ Subscriber.js:89DoSubscriber._next @ do.js:87Subscriber.next @ Subscriber.js:89FilterSubscriber._next @ filter.js:88Subscriber.next @ Subscriber.js:89WithLatestFromSubscriber._tryProject @ withLatestFrom.js:126WithLatestFromSubscriber._next @ withLatestFrom.js:110Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55StateService.start @ StateService.ts:287(anonymous function) @ ComponentController.ts:36SafeSubscriber.__tryOrUnsub @ Subscriber.js:223SafeSubscriber.next @ Subscriber.js:172Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89FirstSubscriber._emitFinal @ first.js:132FirstSubscriber._emit @ first.js:117FirstSubscriber._next @ first.js:96Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55(anonymous function) @ Navigator.ts:64MapSubscriber._next @ map.js:76Subscriber.next @ Subscriber.js:89TakeSubscriber._next @ take.js:79Subscriber.next @ Subscriber.js:89MapSubscriber._next @ map.js:82Subscriber.next @ Subscriber.js:89SkipWhileSubscriber._next @ skipWhile.js:52Subscriber.next @ Subscriber.js:89Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55ReplaySubject.next @ ReplaySubject.js:28Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89ScanSubscriber._tryNext @ scan.js:104ScanSubscriber._next @ scan.js:91Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89MapSubscriber._next @ map.js:82Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89FilterSubscriber._next @ filter.js:88Subscriber.next @ Subscriber.js:89Subject.next @ Subject.js:55Subscriber._next @ Subscriber.js:125Subscriber.next @ Subscriber.js:89MergeMapSubscriber.notifyNext @ mergeMap.js:133InnerSubscriber._next @ InnerSubscriber.js:23Subscriber.next @ Subscriber.js:89CombineLatestSubscriber._tryProject @ combineLatest.js:142CombineLatestSubscriber.notifyNext @ combineLatest.js:126InnerSubscriber._next @ InnerSubscriber.js:23Subscriber.next @ Subscriber.js:89img.onload @ Node.ts:194
```

Finally you see this error:
```
THREE.WebGLProgram: shader error:  0 gl.VALIDATE_STATUS false gl.getProgramInfoLog invalid shaders ERROR: 0:3: 'efineday' : invalid directive name 
ERROR: 0:4: 'efineday' : invalid directive name 
ERROR: 0:5: 'efineday' : invalid directive name 
ERROR: 0:6: 'efineday' : invalid directive name 
ERROR: 0:7: 'efineday' : invalid directive name 
ERROR: 0:8: 'efineday' : invalid directive name 
 ERROR: 0:3: 'efineday' : invalid directive name 
ERROR: 0:4: 'efineday' : invalid directive name 
ERROR: 0:5: 'efineday' : invalid directive name 
ERROR: 0:6: 'efineday' : invalid directive name 
ERROR: 0:9: 'efineday' : invalid directive name 
ERROR: 0:10: 'efineday' : invalid directive name 
ERROR: 0:18: 'saturate' : no matching overloaded function found 
ERROR: 0:18: 'return' : function return is not matching type: 
ERROR: 0:20: 'efineday' : invalid directive name 
ERROR: 0:23: 'Uncharted2Helper' : no matching overloaded function found 
ERROR: 0:23: 'Uncharted2Helper' : no matching overloaded function found 
WARNING: 0:23: Divide by zero error during constant folding
ERROR: 0:23: 'saturate' : no matching overloaded function found 
ERROR: 0:23: 'return' : function return is not matching type: 
```

It seems like the regEx used to find and replace on "define" `/(\W|^|["])define(\W|["]|$)/g` is matching "#define" that occurs in some kind of three.js template.

Since the `\W`in the above is a shorthand for `[^A-Za-z0-9_]` I just used that negated character set and included "#" as one of the characters to **not** match: `[^A-Za-z0-9_#]`

This prevents the above errors and does not seem to break any of the other parts of my application.
