### PR TITLE
Add support for addons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Add support for addons and custom amd module paths
+
 ## [0.4.8]
 - Don't replace #define with #efineday
 - Add support for package main shorthand in module names

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ var app = new EmberApp({
     locale: 'en-us',
     // Optional: Will create a dependencies.txt that will list all the AMD dependencies in the application, default is false
     outputDependencyList: true,
+    // Optional: Causes the findAMDModules method to search these paths in addition to 'app'
+    // All paths are relative to the project root.
+    // If using this in an addon, you can use 'addon'
+    // If you need amd modules discovered from an ember addon dependency, you can use 'node_modules/addon-name/addon'
+    amdModulePaths: [],
     // Optional, defaults to true. If `true` the amd-start and amd-config scripts will be inlined into index.html.
     // This saves xhrs during application boot, so unless you are generating your index.html file on the fly (i.e. from node or rails)
     // you should likely enable this.

--- a/index.js
+++ b/index.js
@@ -433,6 +433,22 @@ module.exports = {
       return file.indexOf('.js') > -1;
     });
 
+    // Allows for custom paths to be searched
+    let amdModulePaths = this.app.options.amd.amdModulePaths || [];
+    amdModulePaths.forEach(function(amdModulePath) {
+      var amdModuleFSPath = path.join(root, amdModulePath);
+
+      var customJsFiles = [];
+      // Check that the path exists before walking
+      if (fs.existsSync(amdModuleFSPath)) {
+        customJsFiles = walk(amdModuleFSPath).filter(function(file) {
+          return file.indexOf('.js') > -1;
+        });
+      }
+
+      jsFiles = jsFiles.concat(customJsFiles);
+    });
+
     // Collect the list of modules used from the amd packages
     var amdModules = [];
     var packages = this.app.options.amd.packages;

--- a/index.js
+++ b/index.js
@@ -430,7 +430,7 @@ module.exports = {
 
     // Get the list of javascript files fromt the application
     var jsFiles = walk(path.join(root, 'app')).filter(function (file) {
-      return file.indexOf('.js') > -1;
+      return path.extname(file) === '.js';
     });
 
     // Allows for custom paths to be searched
@@ -442,7 +442,7 @@ module.exports = {
       // Check that the path exists before walking
       if (fs.existsSync(amdModuleFSPath)) {
         customJsFiles = walk(amdModuleFSPath).filter(function(file) {
-          return file.indexOf('.js') > -1;
+          return path.extname(file) === '.js';
         });
       }
 


### PR DESCRIPTION
For a project I am working on I need to create an ember addon that uses `ember-cli-amd`.
It will act as a component library that I can reuse for many applications.

I will then need to create one or more ember apps that consume that addon and also use `ember-cli-amd`.

With that in mind I need the `findAMDModules` method to be capable of finding modules in both `./addon` for developing the addon and `./node_modules/addon-name/addon` for the apps.