### PR TITLE
Various bugfixes to handle applications that use ember-auto-import 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.0.2]
+- Improved compatibility with ember-auto-import
+    - Fixed issue where not all special characters were getting escaped during webpack eval modification
+    - Fixed issue where build would crash when trying to modify an eval expression without a string literal as the argument (i.e. a variable containing a string being passed to eval)
+
 ## [2.0.0]
 !!!Breaking changes!!
 - Removed unsued functionality

--- a/index.js
+++ b/index.js
@@ -299,9 +299,10 @@ RequireFilter.prototype.processString = function(code) {
   return replaceRequireAndDefine(code, this.amdPackages, this.amdModules);
 };
 
-function write(arr, str, offset) {
-  for (var i = 0, l = str.length; i < l; i++) {
-    arr[offset + i] = str[i];
+function write(arr, str, offset, len) {
+  arr[offset] = str;
+  for (let i = 1; i < len; i++) {
+    arr[offset + i] = undefined;
   }
 }
 
@@ -367,7 +368,9 @@ function replaceRequireAndDefine(code, amdPackages, amdModules) {
           const evalCode = node.arguments[0].value;
           const evalCodeAfter = replaceRequireAndDefine(evalCode, amdPackages, amdModules);
           if (evalCode !== evalCodeAfter) {
-            write(buffer, "eval(\"" + evalCodeAfter.replace(/\n/g, "\\n") + "\");", node.range[0]);
+            const newEvalCode = "eval(" + JSON.stringify(evalCodeAfterDoubleQuoteReplace) + ");";
+            const len = node.range[1] - node.range[0];
+            write(buffer, newEvalCode, node.range[0], len);
           }
         }
 
@@ -385,7 +388,7 @@ function replaceRequireAndDefine(code, amdPackages, amdModules) {
             return;
           }
 
-          write(buffer, identifier, node.range[0]);
+          write(buffer, identifier, node.range[0], node.range[1] - node.range[0]);
         }
         return;
 
@@ -401,7 +404,7 @@ function replaceRequireAndDefine(code, amdPackages, amdModules) {
             return;
           }
 
-          write(buffer, literal, node.range[0]);
+          write(buffer, literal, node.range[0], node.range[1] - node.range[0]);
         }
         return;
     }

--- a/index.js
+++ b/index.js
@@ -368,9 +368,7 @@ function replaceRequireAndDefine(code, amdPackages, amdModules) {
           const evalCode = node.arguments[0].value;
           const evalCodeAfter = replaceRequireAndDefine(evalCode, amdPackages, amdModules);
           if (evalCode !== evalCodeAfter) {
-            const newEvalCode = "eval(" + JSON.stringify(evalCodeAfterDoubleQuoteReplace) + ");";
-            const len = node.range[1] - node.range[0];
-            write(buffer, newEvalCode, node.range[0], len);
+            write(buffer, "eval(" + JSON.stringify(evalCodeAfter) + ");", node.range[0], node.range[1] - node.range[0]);
           }
         }
 

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ function replaceRequireAndDefine(code, amdPackages, amdModules) {
         }
 
         // Dealing with ember-auto-import eval
-        if (node.callee.name === 'eval') {
+        if (node.callee.name === 'eval' && node.arguments[0].type === 'Literal' && typeof node.arguments[0].value === 'string') {
           const evalCode = node.arguments[0].value;
           const evalCodeAfter = replaceRequireAndDefine(evalCode, amdPackages, amdModules);
           if (evalCode !== evalCodeAfter) {


### PR DESCRIPTION
This PR fixes #41 as well as other problems with replacing require and define in the ember-auto-import webpack evals.

 - Fixed an issue in the replace logic for the webpack eval code that was trying to parse arguments passed to eval that were not string literals.
- Fixed an issue where only newline characters were getting escaped in the modified webpack eval code. (Now all special characters should be replaced)
- Fixed an issue where the modified webpack eval code was a different length than the unmodified code. This could cause any file that had ember-auto-import code (vendor.js, test-support.js, etc.) to be malformed. Modify the write function to handle this case.