### PR TITLE
refactor: use espree instead of esprima for parsing the code as an AST

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const fs = require('fs');
 const path = require('path');
 const cheerio = require('cheerio');
 const Filter = require('broccoli-filter');
-const esprima = require('esprima');
+const espree = require('espree');
 const eswalk = require('esprima-walk');
 const _ = require('lodash');
 const beautify_js = require('js-beautify');
@@ -319,8 +319,10 @@ function write(arr, str, range) {
 // Replace require and define by non-conflicting verbs
 function replaceRequireAndDefine(code, amdPackages, amdModules) {
   // Parse the code as an AST
-  const ast = esprima.parseScript(code, {
-    range: true
+  const ast = espree.parse(code, {
+    range: true,
+    ecmaVersion: 9,
+    sourceType: 'script',
   });
 
   // Split the code into an array for easier substitutions

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,14 +309,14 @@
       }
     },
     "acorn": {
-      "version": "6.2.1",
-      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn/-/acorn-6.2.1.tgz",
-      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
+      "version": "7.1.0",
+      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
     },
     "acorn-jsx": {
-      "version": "5.0.1",
-      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
-      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
+      "version": "5.1.0",
+      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
+      "integrity": "sha512-tMUqwBWfLFbJbizRmEcWSLw6HnFzfdJs2sOJEOwwtVPMoH/0Ay+E703oZz78VSXZiiDcZrQ5XKjPIUQixhmgVw=="
     },
     "after": {
       "version": "0.8.2",
@@ -6844,16 +6844,24 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
     },
     "espree": {
-      "version": "6.0.0",
-      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/espree/-/espree-6.0.0.tgz",
-      "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
+      "version": "6.1.2",
+      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/espree/-/espree-6.1.2.tgz",
+      "integrity": "sha512-2iUPuuPP+yW1PZaMSDM9eyVf8D5P0Hi8h83YtZ5bPc/zHYjII5khoixIUTMO794NOY8F/ThF1Bo8ncZILarUTA==",
       "requires": {
-        "acorn": "^6.0.7",
-        "acorn-jsx": "^5.0.0",
-        "eslint-visitor-keys": "^1.0.0"
+        "acorn": "^7.1.0",
+        "acorn-jsx": "^5.1.0",
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.1.0",
+          "resolved": "http://citools.kub.org/nexus/repository/npm-kub/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+          "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A=="
+        }
       }
     },
     "esprima": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-amd",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -309,27 +309,14 @@
       }
     },
     "acorn": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
-      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
-      "dev": true
+      "version": "6.2.1",
+      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn/-/acorn-6.2.1.tgz",
+      "integrity": "sha512-JD0xT5FCRDNyjDda3Lrg/IxFscp9q4tiYtxE1/nOzlKCk7hIRuYjhq1kCNkbPjMRMZuFq20HNQn1I9k8Oj0E+Q=="
     },
     "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
+      "version": "5.0.1",
+      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
     },
     "after": {
       "version": "0.8.2",
@@ -6587,6 +6574,29 @@
         "text-table": "~0.2.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+          "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+          "dev": true,
+          "requires": {
+            "acorn": "^3.0.4"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "resolved": "http://citools.kub.org/nexus/repository/npm-kub/acorn/-/acorn-3.3.0.tgz",
+              "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+              "dev": true
+            }
+          }
+        },
         "ansi-escapes": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
@@ -6615,6 +6625,16 @@
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "espree": {
+          "version": "3.5.4",
+          "resolved": "http://citools.kub.org/nexus/repository/npm-kub/espree/-/espree-3.5.4.tgz",
+          "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+          "dev": true,
+          "requires": {
+            "acorn": "^5.5.0",
+            "acorn-jsx": "^3.0.0"
           }
         },
         "external-editor": {
@@ -6824,23 +6844,23 @@
     "eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "espree": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
-      "dev": true,
+      "version": "6.0.0",
+      "resolved": "http://citools.kub.org/nexus/repository/npm-kub/espree/-/espree-6.0.0.tgz",
+      "integrity": "sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==",
       "requires": {
-        "acorn": "^5.2.1",
-        "acorn-jsx": "^3.0.0"
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
       }
     },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esprima-walk": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "broccoli-filter": "^1.3.0",
     "cheerio": "^1.0.0-rc.2",
     "ember-cli-babel": "^6.16.0",
-    "espree": "6.0.0",
+    "espree": "6.1.2",
     "esprima-walk": "^0.1.0",
     "js-beautify": "^1.9.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "broccoli-filter": "^1.3.0",
     "cheerio": "^1.0.0-rc.2",
     "ember-cli-babel": "^6.16.0",
-    "esprima": "^4.0.1",
+    "espree": "6.0.0",
     "esprima-walk": "^0.1.0",
     "js-beautify": "^1.9.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
[espree](https://github.com/eslint/espree) is an Esprima-compatible JavaScript parser.
It looks to be drop in replacement for the work being done in this addon.

This addon prevented our team from transitioning to native classes in Ember Octane because of the dependency on esprima.


