### PR TITLE
Optionally inline amd-loading script in index.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.2.0]
+- Added `inline` option, which will inject the `amd-loading` script directly into index.html when set to true.
+
 ## [3.1.3]
 - Small improvement to use in addons
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ var app = new EmberApp({
 
     // Optional: the path to javascript file that will be created for loading the AMD modules
     // default: assets
-    loadingFilePath: 'assets'
+    loadingFilePath: 'assets',
+
+    // Optional: Indicates if we should inject scripts directly into index.html, or if we should
+    // write them to separate js files that are loaded by index.html.  When strict fingerprinting
+    // is required, this should be set to true, since there are scenarios where the generated 
+    // amd-loading.js script will not get a unique fingerprint.
+    // default: false
+    inline: false,
   }
 });
 ```

--- a/lib/convert-to-amd-filter.js
+++ b/lib/convert-to-amd-filter.js
@@ -40,7 +40,7 @@ module.exports = class ConvertToAMD extends Filter {
     this.excludePaths = options.amdOptions.excludePaths;
     this.loadingFilePath = (options.amdOptions.loadingFilePath || 'assets').replace(/\/$/, "");
     this.rootURL = options.rootURL || '';
-    this.inline = !!options.amdOptions.inline
+    this.inline = !!options.amdOptions.inline;
 
     // Because the filter is call for partial rebuild during 'ember serve', we need to
     // know what was added/removed for a partial build
@@ -195,20 +195,24 @@ module.exports = class ConvertToAMD extends Filter {
     indexFiles.forEach(indexFile => {
 
       // Add script elements to each index.html to
-      const indexPath = path.join(this.outputPath, indexFile)
+      const indexPath = path.join(this.outputPath, indexFile);
+      if (!fs.existsSync(indexPath)) {
+        // When building for production, tests/index.html will not exist, so we can skip its loading scripts
+        return;
+      }
       const cheerioQuery = cheerio.load(fs.readFileSync(indexPath));
       const amdScripts = [ `<script src="${this.loader}" data-amd=true></script>` ];
       const scripts = this.indexHtmlCaches[indexFile].scriptsToLoad.join(',');
       const loadingScript = beautify_js(amdLoadingTemplate(_.assign(moduleInfos, { scripts })), {
         indent_size: 2,
         max_preserve_newlines: 1
-      })
+      });
 
       if (this.inline) {
-        amdScripts.push(`<script>${loadingScript}</script>`)
+        amdScripts.push(`<script>${loadingScript}</script>`);
       } else {
         // Add a script tag to index.html to load the amd-loading script, and write the script to the output directory
-        amdScripts.push(`<script src="${this.indexHtmlCaches[indexFile].loadingScript}" data-amd-loading=true></script>`)
+        amdScripts.push(`<script src="${this.indexHtmlCaches[indexFile].loadingScript}" data-amd-loading=true></script>`);
         fs.writeFileSync(path.join(this.outputPath, this.indexHtmlCaches[indexFile].loadingScript), loadingScript);
       }
 
@@ -217,12 +221,12 @@ module.exports = class ConvertToAMD extends Filter {
         fs.writeFileSync(path.join(this.outputPath, this.indexHtmlCaches[indexFile].afterLoadingScript), this.indexHtmlCaches[indexFile].afterLoadingCode);
       }
 
-      cheerioQuery('body').prepend(amdScripts.join('\n'))
+      cheerioQuery('body').prepend(amdScripts.join('\n'));
       const html = beautify_html(cheerioQuery.html(), {
         indentSize: 2,
         max_preserve_newlines: 0
-      })
-      fs.writeFileSync(indexPath, html)
+      });
+      fs.writeFileSync(indexPath, html);
     });
 
     return result;

--- a/lib/convert-to-amd-filter.js
+++ b/lib/convert-to-amd-filter.js
@@ -40,8 +40,9 @@ module.exports = class ConvertToAMD extends Filter {
     this.excludePaths = options.amdOptions.excludePaths;
     this.loadingFilePath = (options.amdOptions.loadingFilePath || 'assets').replace(/\/$/, "");
     this.rootURL = options.rootURL || '';
+    this.inline = !!options.amdOptions.inline
 
-    // Because the filter is call for partial rebuild during 'ember serve', we need to 
+    // Because the filter is call for partial rebuild during 'ember serve', we need to
     // know what was added/removed for a partial build
     this.externalAmdModules = new Set();
     this.externalAmdModulesCache = new Map();
@@ -127,11 +128,6 @@ module.exports = class ConvertToAMD extends Filter {
 
     // Replace the original ember scripts by the amd ones
     scriptElements.remove();
-    const amdScripts = [
-      `<script src="${this.loader}" data-amd=true></script>`,
-      `<script src="${this.indexHtmlCaches[relativePath].loadingScript}" data-amd-loading=true></script>`
-    ];
-    cheerioQuery('body').prepend(amdScripts.join('\n'));
 
     // Beautify the index.html
     return beautify_html(cheerioQuery.html(), {
@@ -180,8 +176,8 @@ module.exports = class ConvertToAMD extends Filter {
 
   async build() {
 
-    // Clear before each build since the filter is kept by ember-cli during 'ember serve' 
-    // and being reused without going thru postProcessTree. If we don't clean we may get 
+    // Clear before each build since the filter is kept by ember-cli during 'ember serve'
+    // and being reused without going thru postProcessTree. If we don't clean we may get
     // previous modules.
     this.externalAmdModules.clear();
 
@@ -194,22 +190,39 @@ module.exports = class ConvertToAMD extends Filter {
       });
     });
 
-    // Write the various sript files we need 
+    // Write the various script files we need
     const moduleInfos = this._buildModuleInfos();
     indexFiles.forEach(indexFile => {
 
-      // The loading script
+      // Add script elements to each index.html to
+      const indexPath = path.join(this.outputPath, indexFile)
+      const cheerioQuery = cheerio.load(fs.readFileSync(indexPath));
+      const amdScripts = [ `<script src="${this.loader}" data-amd=true></script>` ];
       const scripts = this.indexHtmlCaches[indexFile].scriptsToLoad.join(',');
-      const loadingScript = amdLoadingTemplate(_.assign(moduleInfos, { scripts }));
-      fs.writeFileSync(path.join(this.outputPath, this.indexHtmlCaches[indexFile].loadingScript), beautify_js(loadingScript, {
+      const loadingScript = beautify_js(amdLoadingTemplate(_.assign(moduleInfos, { scripts })), {
         indent_size: 2,
         max_preserve_newlines: 1
-      }));
+      })
+
+      if (this.inline) {
+        amdScripts.push(`<script>${loadingScript}</script>`)
+      } else {
+        // Add a script tag to index.html to load the amd-loading script, and write the script to the output directory
+        amdScripts.push(`<script src="${this.indexHtmlCaches[indexFile].loadingScript}" data-amd-loading=true></script>`)
+        fs.writeFileSync(path.join(this.outputPath, this.indexHtmlCaches[indexFile].loadingScript), loadingScript);
+      }
 
       // After loading script
       if (this.indexHtmlCaches[indexFile].afterLoadingCode) {
         fs.writeFileSync(path.join(this.outputPath, this.indexHtmlCaches[indexFile].afterLoadingScript), this.indexHtmlCaches[indexFile].afterLoadingCode);
       }
+
+      cheerioQuery('body').prepend(amdScripts.join('\n'))
+      const html = beautify_html(cheerioQuery.html(), {
+        indentSize: 2,
+        max_preserve_newlines: 0
+      })
+      fs.writeFileSync(indexPath, html)
     });
 
     return result;

--- a/lib/convert-to-amd-filter.js
+++ b/lib/convert-to-amd-filter.js
@@ -194,12 +194,13 @@ module.exports = class ConvertToAMD extends Filter {
     const moduleInfos = this._buildModuleInfos();
     indexFiles.forEach(indexFile => {
 
-      // Add script elements to each index.html to
       const indexPath = path.join(this.outputPath, indexFile);
       if (!fs.existsSync(indexPath)) {
         // When building for production, tests/index.html will not exist, so we can skip its loading scripts
         return;
       }
+
+      // We add scripts to each index.html file to kick off the loading of amd modules.
       const cheerioQuery = cheerio.load(fs.readFileSync(indexPath));
       const amdScripts = [ `<script src="${this.loader}" data-amd=true></script>` ];
       const scripts = this.indexHtmlCaches[indexFile].scriptsToLoad.join(',');
@@ -209,6 +210,7 @@ module.exports = class ConvertToAMD extends Filter {
       });
 
       if (this.inline) {
+        // Inline the amd-loading script directly in index.html
         amdScripts.push(`<script>${loadingScript}</script>`);
       } else {
         // Add a script tag to index.html to load the amd-loading script, and write the script to the output directory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-amd",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Ember CLI Addon that can load AMD modules.",
   "scripts": {
     "build": "ember build --environment=production",

--- a/tests/dummy/app/components/esri-map.js
+++ b/tests/dummy/app/components/esri-map.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 
-import Map from 'esri/Map';
+import Map from 'esri/map';
 
 const EsriMapComponent = Component.extend({
     didInsertElement() {

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -9,6 +9,10 @@
 
     {{content-for "head"}}
 
+    <script>
+      window.dojoConfig = { async: true }
+    </script>
+
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link integrity="" rel="stylesheet" href="{{rootURL}}assets/dummy.css">
 

--- a/tests/dummy/config/dojo-config.js
+++ b/tests/dummy/config/dojo-config.js
@@ -1,3 +1,0 @@
-window.dojoConfig = {
-    async: true
-};

--- a/tests/index.html
+++ b/tests/index.html
@@ -14,6 +14,10 @@
     <link rel="stylesheet" href="{{rootURL}}assets/dummy.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
+    <script>
+      window.dojoConfig = { async: true }
+    </script>
+
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>


### PR DESCRIPTION
This is a proposed workaround for https://github.com/Esri/ember-cli-amd/issues/57

When the `inline` option is provided with a truthy value, we will inline the content of the amd-loading.js script in index.html, rather than write it as a separate asset.  

If the option is falsy or omitted, the behavior should match the current behavior in master.